### PR TITLE
move restart logic to update script

### DIFF
--- a/canaries/2D_image_stream.py
+++ b/canaries/2D_image_stream.py
@@ -1,6 +1,4 @@
 import asyncio
-import os
-import time
 
 import cv2
 import datetime
@@ -41,11 +39,6 @@ def get_frames_per_sec(ordered_frames):
         ordered_frames.popleft()
     return len(ordered_frames)
 
-def restart_server():
-    logging.info("restarting the viam-server...")
-    os.system("systemctl restart viam-server")
-    time.sleep(30)  # give the viam-server time to restart
-    logging.info("viam-server up")
 
 async def main():
     robot = None
@@ -85,7 +78,6 @@ async def main():
         except Exception as e:
             logging.info(f"caught exception '{e}'")
             close_robot(robot)
-            restart_server()
             continue
     logging.info(f"cannot get image. {attempts} attempts tried and failed")
 

--- a/canaries/update
+++ b/canaries/update
@@ -38,12 +38,25 @@ echo "downloading $VSE to $CV..."
 git clone https://github.com/viamrobotics/vision-service-examples.git "$CV"
 echo "$VSE downloaded"
 
-# RESTART THE VIAM SERVER
-echo "restarting the viam-server"
-echo $PASSWORD | sudo -S systemctl restart viam-server.service
-sleep 30  # give the server some time to properly shutdown and startup
-echo "viam-server up"
+# TRY TO DISPLAY THE STREAM AT MOST THREE TIMES, RETRYING THE SERVER EACH TIME
+attemp=0
+until [ "$attemp" -ge 3 ]
+do
+  echo "restarting the viam-server"
+  echo $PASSWORD | sudo -S systemctl restart viam-server.service
+  sleep 30  # give the server some time to properly shutdown and startup
+  echo "viam-server up"
 
-# RESTART SCRIPTS
-echo "displaying xterm window..."
-DISPLAY=:0 xterm -e "echo $PASSOWRD | sudo -S python3 $CV/canaries/2D_image_stream.py"
+  echo "displaying xterm window..."
+  statusfile=$(mktemp)
+  DISPLAY=:0 xterm -e "python3 $CV/canaries/2D_image_stream.py; echo $? > $statusfile"
+  status=$(cat $statusfile)
+  rm $statusfile
+
+  if [ $status -eq 0 ]; then
+    break
+  fi
+
+  attemp=$((attemp+1))
+done
+


### PR DESCRIPTION
I tried to restart the server in the python script, which failed. Now attempting to restart the viam-server on failed attempts in the update script. I can't just push these commits anymore for some reason. The main branch is now protected. Restarting the viam-server fixes most issues and I still get emails on each attempt so any failures are permanently logged.