### PR TITLE
simplify success/failure output

### DIFF
--- a/canaries/update
+++ b/canaries/update
@@ -39,7 +39,6 @@ git clone https://github.com/viamrobotics/vision-service-examples.git "$CV"
 echo "$VSE downloaded"
 
 # TRY TO DISPLAY THE STREAM AT MOST THREE TIMES, RETRYING THE SERVER EACH TIME
-success=false
 attempt=0
 until [ "$attempt" -ge 3 ]
 do
@@ -55,15 +54,12 @@ do
   rm $statusfile
 
   if [ "$status" = 0 ]; then
-    success=true
-    break
+    echo "success"
+    exit
   fi
 
   attempt=$((attempt+1))
 done
 
-if $success; then
-  echo "success"
-else
-  echo "failure"
-fi
+echo "failure"
+exit 1


### PR DESCRIPTION
After playing with boolean logic I'm now seeing the error
```
/bin/sh: 1: /home/viam-cv/vision-service-examples/canaries/update: Permission denied
```
No idea why, but I could eliminate the possibility that it's my poor attempt at boolean logic and branch statements in bash by not using them.